### PR TITLE
Return EXIT_SUCCESS with valid `-h` (help) option

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -543,7 +543,7 @@ static void OPTQUAL Set_zf( void )  { Options.fctype = OptValue; }
 
 static void OPTQUAL Set_zt( void ) { Options.stdcall_decoration = OptValue; }
 #ifndef __SW_BD
-static void OPTQUAL Set_h( void ) {  PrintUsage();  exit(1); }
+static void OPTQUAL Set_h( void ) {  PrintUsage();  exit(EXIT_SUCCESS); }
 #endif
 
 static void OPTQUAL Set_zv(void) { Options.vectorcall_decoration = OptValue; }


### PR DESCRIPTION
# Help command should return `EXIT_SUCCESS`

`Set_h` should return `EXIT_SUCCESS` because `-h` is a valid `help` command line option and doesn't require any other parameter.

## Fix

Proposal:
```c
static void OPTQUAL Set_h( void ) {  PrintUsage();  exit(EXIT_SUCCESS); }
```

Current state (incorrect):
```c
static void OPTQUAL Set_h( void ) {  PrintUsage();  exit(1); }
```