### PR TITLE
No Need to Hard Code CC in gccLinux64.mak

### DIFF
--- a/gccLinux64.mak
+++ b/gccLinux64.mak
@@ -21,8 +21,6 @@ endif
 
 c_flags =-D __UNIX__ $(extra_c_flags)
 
-CC = gcc
-
 .SUFFIXES:
 .SUFFIXES: .c .o
 


### PR DESCRIPTION
There is no need to hard code the value of CC to "gcc" in gccLinux64.mak, as this value will default to `cc` and with a normal GNU Toolchain `cc` will be `gcc` anyway. By removing the explicit definition this also allows users to specify their own compiler (such as clang) with something like `CC=clang make -f gccLinux64.mak`.